### PR TITLE
Catch RemoteError if scanner has crashed

### DIFF
--- a/web.py
+++ b/web.py
@@ -236,7 +236,10 @@ def get_pokemarkers():
 
     if config.MAP_WORKERS:
         # Worker stats
-        markers.extend(get_worker_markers())
+        try:
+            markers.extend(get_worker_markers())
+        except RemoteError:
+            print('Unable to connect to manager for worker data.')
     return markers
 
 def get_spawnpointsmarkers():


### PR DESCRIPTION
If you restart the scanner (because it has crashed for e.g.)
but don't restart the web script it won't show any data

This way only the Worker status will be missing.