### PR TITLE
Telegram notification bug fixing

### DIFF
--- a/monocle/notification.py
+++ b/monocle/notification.py
@@ -395,6 +395,7 @@ class Notification:
                         self.log.error('Error {} from Telegram: {}', e.code, e.message)
                     return False
                 self.log.info('Sent a Telegram notification about {}.', self.name)
+                return True
         except (ClientError, DisconnectedError) as e:
             err = e.__cause__ or e
             self.log.error('{} during Telegram notification.', err.__class__.__name__)


### PR DESCRIPTION
Notifications were being sent but, without the 'return True' at the end of method sendToTelegram, the encounter cache was being cleaned up (since notified = False at monocle/notification.py, class Notifier), which in turn prompted multiple subsequent notifications of past encounters (because they were being treated as new).