### PR TITLE
Update fields sent via Webhook

### DIFF
--- a/monocle/notification.py
+++ b/monocle/notification.py
@@ -796,6 +796,9 @@ class Notifier:
             data['message']['individual_stamina'] = pokemon['individual_stamina']
             data['message']['move_1'] = pokemon['move_1']
             data['message']['move_2'] = pokemon['move_2']
+            data['message']['height'] = pokemon['height']
+            data['message']['weight'] = pokemon['weight']
+            data['message']['gender'] = pokemon['gender']
         except KeyError:
             pass
 

--- a/monocle/worker.py
+++ b/monocle/worker.py
@@ -941,6 +941,9 @@ class Worker:
             pokemon['individual_attack'] = pdata.get('individual_attack', 0)
             pokemon['individual_defense'] = pdata.get('individual_defense', 0)
             pokemon['individual_stamina'] = pdata.get('individual_stamina', 0)
+            pokemon['height'] = pdata['height_m']
+            pokemon['weight'] = pdata['weight_kg']
+            pokemon['gender'] = pdata['pokemon_display']['gender']
         except KeyError:
             self.log.error('Missing Pokemon data in encounter response.')
         self.error_code = '!'


### PR DESCRIPTION
Because PokeAlarm since https://github.com/kvangent/PokeAlarm/commit/cca3d39020ccf52e0573c13de0ced002ad006ebb will ignore all Pokemon if ignore_unknown is
enabled as the size is missing.