### PR TITLE
Auto-pan popup only once. Closes #222.

### DIFF
--- a/monocle/static/js/main.js
+++ b/monocle/static/js/main.js
@@ -133,9 +133,11 @@ function PokemonMarker (raw) {
     marker.raw = raw;
     markers[raw.id] = marker;
     marker.on('popupopen',function popupopen (event) {
+        event.popup.options.autoPan = true; // Pan into view once
         event.popup.setContent(getPopupContent(event.target.raw));
         event.target.popupInterval = setInterval(function () {
             event.popup.setContent(getPopupContent(event.target.raw));
+            event.popup.options.autoPan = false; // Don't fight user panning
         }, 1000);
     });
     marker.on('popupclose', function (event) {


### PR DESCRIPTION
When a sighting information popup is displayed on the map and the user pans away from it, the popup takes control away from the user and pans itself back into view. Having to manually close the popup and then pan back to the desired area again is frustrating.

This change makes the popup pan itself into view only once (when first opened), and then return control to the user.