### PR TITLE
Prevent double encounter the same pokemon

### DIFF
--- a/monocle/worker.py
+++ b/monocle/worker.py
@@ -755,7 +755,7 @@ class Worker:
                             self.log.warning('{} during encounter', e.__class__.__name__)
 
                 if notify_conf and self.notifier.eligible(normalized):
-                    if encounter_conf and 'move1' not in normalized:
+                    if encounter_conf and 'move_1' not in normalized:
                         try:
                             await self.encounter(normalized, pokemon['spawn_point_id'])
                         except CancelledError:


### PR DESCRIPTION
There was a typo in e7511c9d35d5eb7f9 . The attribute name in `normalized_pokemon` should be `move_1`, not `move1`.
