### PR TITLE
[fix]tutorial_completion rpc_api warning

### DIFF
--- a/monocle/worker.py
+++ b/monocle/worker.py
@@ -261,7 +261,7 @@ class Worker:
             await self.random_sleep(.5, 4)
 
             request = self.api.create_request()
-            request.mark_tutorial_complete(tutorials_completed=1)
+            request.mark_tutorial_complete(tutorials_completed=[1])
             await self.call(request, buddy=False)
 
         await self.random_sleep(.5, 1)
@@ -440,14 +440,14 @@ class Worker:
             await sleep(.13, loop=LOOP)
 
             request = self.api.create_request()
-            request.mark_tutorial_complete(tutorials_completed=4)
+            request.mark_tutorial_complete(tutorials_completed=[4])
             await self.call(request, buddy=False)
 
         if 7 not in tutorial_state:
             # first time experience
             await self.random_sleep(3.9, 4.5)
             request = self.api.create_request()
-            request.mark_tutorial_complete(tutorials_completed=7)
+            request.mark_tutorial_complete(tutorials_completed=[7])
             await self.call(request)
 
         if starter_id:


### PR DESCRIPTION
FIxed the tutorial warning message.

  [2017-05-28 04:40:53][ WARNING][aiopogo.rpc_api] Argument
  tutorials_completed with value 7 inside mark_tutorial_complete_message
  should be a sequence.