### PR TITLE
Fix `cache_handle` problem when webhook fail

### DIFF
--- a/monocle/notification.py
+++ b/monocle/notification.py
@@ -719,7 +719,7 @@ class Notifier:
 
         if 'time_till_hidden' not in pokemon:
             seen = pokemon['seen'] % 3600
-            self.cache.store.add(pokemon['encounter_id'])
+            cache_handle = self.cache.store.add(pokemon['encounter_id'])
             try:
                 with session_scope() as session:
                     tth = await run_threaded(estimate_remaining_time, session, pokemon['spawn_id'], seen)


### PR DESCRIPTION
When the case is eligible for webhook, but the webhook failed (due to, for example, timeout, or server error), an exception is throw on line 255 due to missing `cache_handle`. 
This patch fix the issue.